### PR TITLE
Fix crash related with content inset observer

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -202,6 +202,7 @@ static char UIScrollViewPullToRefreshView;
         if (scrollView.showsPullToRefresh) {
             if (self.isObserving) {
                 //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
+                [scrollView removeObserver:self forKeyPath:@"contentInset"];
                 [scrollView removeObserver:self forKeyPath:@"contentOffset"];
                 [scrollView removeObserver:self forKeyPath:@"contentSize"];
                 [scrollView removeObserver:self forKeyPath:@"frame"];


### PR DESCRIPTION
Hi @dinhviethoa , it's a nice fix but it crashes when you try to deallocate the scrollView. 
